### PR TITLE
Add deprecation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repo is used to document research performed by the packit team.
 * [`git notes` as a storage of our data](./git_notes)
 * [Tools/libraries similar or related to the Packit](./automation-tools)
 * [Zuul CI](./zuul)
+* [Deprecation policy](./deprecation)
 
 
 ## Organization of this repository

--- a/deprecation/README.md
+++ b/deprecation/README.md
@@ -1,0 +1,5 @@
+# Deprecation policy
+
+* `Deprecated` PyPI package is used for deprecation
+* annotate deprecated functions with `@depracted` decorator, optionally with message
+* functions will be removed after 6 months from the release where they were marked as deprecated

--- a/deprecation/README.md
+++ b/deprecation/README.md
@@ -1,18 +1,49 @@
 # Deprecation policy
 
-* `Deprecated` PyPI package is used for deprecation
-* annotate deprecated functions with `@depracted` decorator, optionally with message
-* functions will be removed after 6 months from the release in which they were marked as deprecated
+- `Deprecated` PyPI package is used for deprecation
+- annotate deprecated functions with `@depracted` decorator, optionally with message
+- functions will be removed after 6 months from the release in which they were marked as deprecated
 
 ## Choice of library
 
 Looked into the options suggested by @lachmanfrantisek which were:
 
-* `Deprecated`
-  * seems as a good choice, offers decorator that has optional parameters such as version or custom message
+- `Deprecated`
 
-* `Python-Deprecated`
-  * deprecated `Deprecated`, which is probably kept in PyPI just for backward-compatibility
+  - seems as a good choice, offers decorator that has optional parameters such as version or custom message
+  - live GitHub repo
+  - fast release cycle
+  - has only enhancements in issues
+  - [docs](https://deprecated.readthedocs.io/en/latest/?badge=latest)
+  - `@deprecated(reason='', version='', action='always', category=<class 'DeprecationWarning'>)`
+    from docs, all properties are optional, you can add reason (usually alternative) or version in which it was deprecated
 
-* `warnings` (built-in module)
-  * seems like a lot of copy pasting of the same code, or manual implementation of `@deprecated`
+- `Python-Deprecated`
+
+  - dead version of `Deprecated`, which is probably kept in PyPI just for backward-compatibility
+
+- `deprecationlib`
+
+  - seems like hobby project, only one information in decorator (alternative function name)
+
+- `Dandelyon`
+
+  - looks like nice project
+  - offers multiple decorators
+  - doesn't seem to be very active
+
+- `deprecate`
+
+  - dead project
+
+- `deprecation`
+
+  - not very active
+  - multiple issues
+
+- `libdeprecation`
+
+  - dead version of `deprecation`
+
+- `warnings` (built-in module)
+  - seems like a lot of copy pasting of the same code, or manual implementation of `@deprecated`

--- a/deprecation/README.md
+++ b/deprecation/README.md
@@ -2,4 +2,17 @@
 
 * `Deprecated` PyPI package is used for deprecation
 * annotate deprecated functions with `@depracted` decorator, optionally with message
-* functions will be removed after 6 months from the release where they were marked as deprecated
+* functions will be removed after 6 months from the release in which they were marked as deprecated
+
+## Choice of library
+
+Looked into the options suggested by @lachmanfrantisek which were:
+
+* `Deprecated`
+  * seems as a good choice, offers decorator that has optional parameters such as version or custom message
+
+* `Python-Deprecated`
+  * deprecated `Deprecated`, which is probably kept in PyPI just for backward-compatibility
+
+* `warnings` (built-in module)
+  * seems like a lot of copy pasting of the same code, or manual implementation of `@deprecated`


### PR DESCRIPTION
Related to packit-service/ogr#121

I looked into the options suggested by @lachmanfrantisek which were:
- `Deprecated`
  - seems as a good choice, offers decorator that has optional parameters such as version or custom message

- `Python-Deprecated`
  - deprecated `Deprecated`, which is probably kept in PyPI just for backward-compatibility

- `warnings` (built-in module)
  - seems like a lot of copy pasting of the same code, or manual implementation of `@deprecated`