### PR TITLE
Update pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.16.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
pyupgrade v3.15.0 and v3.16.0 have a bug with Python 3.14's tokenize module API changes. The v3.21.2 update fixes this.