### PR TITLE
Pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/opened-prs-to-the-board.yml
+++ b/.github/workflows/opened-prs-to-the-board.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.3.0
+      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
         with:
           project-url: https://github.com/orgs/packit/projects/14
           github-token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}

--- a/.github/workflows/test-deployment.yml
+++ b/.github/workflows/test-deployment.yml
@@ -12,11 +12,11 @@ jobs:
     name: Test deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: "packit/packit.dev"
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: 18
           cache: yarn
@@ -28,7 +28,7 @@ jobs:
         run: rm -rf .research-docs research
 
       - name: Checkout the PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           path: ".research-docs"
 

--- a/.github/workflows/trigger-packit-dev.yml
+++ b/.github/workflows/trigger-packit-dev.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger packit.dev
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570 # v2
         with:
           token: ${{ secrets.PACKIT_DEV_TOKEN }}
           repository: packit/packit.dev


### PR DESCRIPTION
Pin all actions to specific commit SHAs to
prevent supply chain attacks and ensure reproducible builds.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>